### PR TITLE
Save and load methods in Dataset + mics uI improvements

### DIFF
--- a/src/omnipy/__init__.py
+++ b/src/omnipy/__init__.py
@@ -4,6 +4,8 @@ import os
 import sys
 from typing import Optional
 
+from omnipy.data.dataset import Dataset
+from omnipy.data.model import Model
 from omnipy.hub.runtime import Runtime
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -21,3 +23,5 @@ def _get_runtime() -> Optional['Runtime']:
 
 
 runtime: Optional['Runtime'] = _get_runtime()
+
+__all__ = [Model, Dataset]

--- a/src/omnipy/api/protocols/public/data.py
+++ b/src/omnipy/api/protocols/public/data.py
@@ -2,7 +2,9 @@ from typing import Any, Callable, IO, Iterator, Protocol, Type, TypeVar
 
 from pydantic.fields import Undefined, UndefinedType
 
-ModelT = TypeVar("ModelT")
+from omnipy.api.protocols.private.log import CanLog
+
+ModelT = TypeVar('ModelT')
 
 
 class IsDataset(Protocol[ModelT]):
@@ -129,4 +131,7 @@ class IsSerializerRegistry(Protocol):
         ...
 
     def detect_tar_file_serializers_from_file_suffix(self, file_suffix: str):
+        ...
+
+    def load_from_tar_file_path(self, log_obj: CanLog, tar_file_path: str, to_dataset: IsDataset):
         ...

--- a/src/omnipy/api/protocols/public/data.py
+++ b/src/omnipy/api/protocols/public/data.py
@@ -37,7 +37,7 @@ class IsDataset(Protocol[ModelT]):
                   update: bool = True) -> None:
         ...
 
-    def to_json(self, pretty=False) -> dict[str, str]:
+    def to_json(self, pretty=True) -> dict[str, str]:
         ...
 
     def from_json(self,
@@ -46,7 +46,7 @@ class IsDataset(Protocol[ModelT]):
         ...
 
     @classmethod
-    def to_json_schema(cls, pretty=False) -> str | dict[str, str]:
+    def to_json_schema(cls, pretty=True) -> str | dict[str, str]:
         ...
 
     def as_multi_model_dataset(self) -> 'MultiModelDataset[ModelT]':

--- a/src/omnipy/api/protocols/public/data.py
+++ b/src/omnipy/api/protocols/public/data.py
@@ -1,0 +1,132 @@
+from typing import Any, Callable, IO, Iterator, Protocol, Type, TypeVar
+
+from pydantic.fields import Undefined, UndefinedType
+
+ModelT = TypeVar("ModelT")
+
+
+class IsDataset(Protocol[ModelT]):
+    """
+    Dict-based container of data files that follow a specific Model
+    """
+    def __init__(
+        self,
+        value: dict[str, object] | Iterator[tuple[str, object]] | UndefinedType = Undefined,
+        *,
+        data: dict[str, object] | UndefinedType = Undefined,
+        **input_data: object,
+    ) -> None:
+        ...
+
+    @classmethod
+    def get_model_class(cls) -> Type[ModelT]:
+        """
+        Returns the concrete Model class used for all data files in the dataset, e.g.:
+        `Model[list[int]]`
+        :return: The concrete Model class used for all data files in the dataset
+        """
+        ...
+
+    def to_data(self) -> dict[str, Any]:
+        ...
+
+    def from_data(self,
+                  data: dict[str, Any] | Iterator[tuple[str, Any]],
+                  update: bool = True) -> None:
+        ...
+
+    def to_json(self, pretty=False) -> dict[str, str]:
+        ...
+
+    def from_json(self,
+                  data: dict[str, str] | Iterator[tuple[str, str]],
+                  update: bool = True) -> None:
+        ...
+
+    @classmethod
+    def to_json_schema(cls, pretty=False) -> str | dict[str, str]:
+        ...
+
+    def as_multi_model_dataset(self) -> 'MultiModelDataset[ModelT]':
+        ...
+
+
+class MultiModelDataset(Protocol[ModelT]):
+    """
+        Variant of Dataset that allows custom models to be set on individual data files
+    """
+    def set_model(self, obj_type: str, model: ModelT) -> None:
+        ...
+
+    def get_model(self, obj_type: str) -> ModelT:
+        ...
+
+
+class IsSerializer(Protocol):
+    """"""
+    @classmethod
+    def is_dataset_directly_supported(cls, dataset: IsDataset) -> bool:
+        pass
+
+    @classmethod
+    def get_dataset_cls_for_new(cls) -> Type[IsDataset]:
+        pass
+
+    @classmethod
+    def get_output_file_suffix(cls) -> str:
+        pass
+
+    @classmethod
+    def serialize(cls, dataset: IsDataset) -> bytes | memoryview:
+        pass
+
+    @classmethod
+    def deserialize(cls, serialized: bytes) -> IsDataset:
+        pass
+
+
+class IsTarFileSerializer(IsSerializer):
+    @classmethod
+    def create_tarfile_from_dataset(cls,
+                                    dataset: IsDataset,
+                                    data_encode_func: Callable[[Any], bytes | memoryview]):
+        """"""
+
+    @classmethod
+    def create_dataset_from_tarfile(cls,
+                                    dataset: IsDataset,
+                                    tarfile_bytes: bytes,
+                                    data_decode_func: Callable[[IO[bytes]], Any],
+                                    dictify_object_func: Callable[[str, Any], dict | str],
+                                    import_method='from_data'):
+        ...
+
+
+class IsSerializerRegistry(Protocol):
+    """"""
+    def __init__(self) -> None:
+        ...
+
+    def register(self, serializer_cls: Type[IsSerializer]) -> None:
+        ...
+
+    @property
+    def serializers(self) -> tuple[Type[IsSerializer], ...]:
+        ...
+
+    @property
+    def tar_file_serializers(self) -> tuple[Type[IsTarFileSerializer], ...]:
+        ...
+
+    def auto_detect(self, dataset: IsDataset):
+        ...
+
+    def auto_detect_tar_file_serializer(self, dataset: IsDataset):
+        ...
+
+    @classmethod
+    def _autodetect_serializer(cls, dataset, serializers):
+        ...
+
+    def detect_tar_file_serializers_from_file_suffix(self, file_suffix: str):
+        ...

--- a/src/omnipy/api/protocols/public/data.py
+++ b/src/omnipy/api/protocols/public/data.py
@@ -57,10 +57,10 @@ class MultiModelDataset(Protocol[ModelT]):
     """
         Variant of Dataset that allows custom models to be set on individual data files
     """
-    def set_model(self, obj_type: str, model: ModelT) -> None:
+    def set_model(self, data_file: str, model: ModelT) -> None:
         ...
 
-    def get_model(self, obj_type: str) -> ModelT:
+    def get_model(self, data_file: str) -> ModelT:
         ...
 
 

--- a/src/omnipy/api/protocols/public/hub.py
+++ b/src/omnipy/api/protocols/public/hub.py
@@ -11,6 +11,7 @@ from omnipy.api.protocols.public.config import (IsDataConfig,
                                                 IsLocalRunnerConfig,
                                                 IsPrefectEngineConfig,
                                                 IsRootLogConfig)
+from omnipy.api.protocols.public.data import IsSerializerRegistry
 
 
 class IsRootLogObjects(Protocol):
@@ -53,6 +54,7 @@ class IsRuntimeObjects(Protocol):
     local: IsEngine
     prefect: IsEngine
     registry: IsRunStateRegistry
+    serializers: IsSerializerRegistry
     root_log: IsRootLogObjects
 
     def __init__(
@@ -61,6 +63,7 @@ class IsRuntimeObjects(Protocol):
             local: IsEngine | None = None,  # noqa
             prefect: IsEngine | None = None,  # noqa
             registry: IsRunStateRegistry | None = None,  # noqa
+            serializers: IsSerializerRegistry | None = None,
             root_log: IsRootLogObjects | None = None,  # noqa
             *args: object,
             **kwargs: object) -> None:

--- a/src/omnipy/compute/mixins/iterate.py
+++ b/src/omnipy/compute/mixins/iterate.py
@@ -82,7 +82,7 @@ class IterateFuncJobBaseMixin:
                         out_dataset = out_dataset_cls()
 
                         for title, data_file in dataset.items():
-                            out_dataset[title] = inner_func(data_file, *args, **kwargs)
+                            out_dataset[title] = inner_func(data_file.contents, *args, **kwargs)
 
                         return out_dataset
 

--- a/src/omnipy/data/dataset.py
+++ b/src/omnipy/data/dataset.py
@@ -271,7 +271,7 @@ class Dataset(GenericModel, Generic[ModelT], UserDict):
     def absorb_and_replace(self, other: 'Dataset'):
         self.from_data(other.to_data(), update=False)
 
-    def to_json(self, pretty=False) -> dict[str, str]:
+    def to_json(self, pretty=True) -> dict[str, str]:
         result = {}
 
         for key, val in self.to_data().items():
@@ -310,7 +310,7 @@ class Dataset(GenericModel, Generic[ModelT], UserDict):
     #     return self.__class__.create_from_json, (self.to_json(),)
 
     @classmethod
-    def to_json_schema(cls, pretty=False) -> str | dict[str, str]:
+    def to_json_schema(cls, pretty=True) -> str | dict[str, str]:
         result = {}
         schema = cls.schema()
         for key, val in schema['properties']['data'].items():

--- a/src/omnipy/data/dataset.py
+++ b/src/omnipy/data/dataset.py
@@ -265,6 +265,12 @@ class Dataset(GenericModel, Generic[ModelT], UserDict):
             new_model.from_data(obj_val)
             self[data_file] = new_model
 
+    def absorb(self, other: 'Dataset'):
+        self.from_data(other.to_data(), update=True)
+
+    def absorb_and_replace(self, other: 'Dataset'):
+        self.from_data(other.to_data(), update=False)
+
     def to_json(self, pretty=False) -> dict[str, str]:
         result = {}
 
@@ -347,7 +353,8 @@ class Dataset(GenericModel, Generic[ModelT], UserDict):
         serializer_registry = self._get_serializer_registry()
         return serializer_registry.load_from_tar_file_path(self, directory, self)
 
-    def _get_serializer_registry(self):
+    @staticmethod
+    def _get_serializer_registry():
         from omnipy import runtime
         if len(runtime.objects.serializers.serializers) == 0:
             from omnipy.modules import register_serializers

--- a/src/omnipy/data/model.py
+++ b/src/omnipy/data/model.py
@@ -17,7 +17,7 @@ from typing import (Annotated,
 
 # from orjson import orjson
 from pydantic import NoneIsNotAllowedError
-from pydantic import Protocol as pydantic_protocol
+from pydantic import Protocol as PydanticProtocol
 from pydantic import root_validator, ValidationError
 from pydantic.fields import ModelField, Undefined, UndefinedType
 from pydantic.generics import GenericModel
@@ -224,8 +224,6 @@ class Model(GenericModel, Generic[RootT], metaclass=MyModelMetaclass):
             model = cls._populate_root_field(model)
 
         created_model = super().__class_getitem__(model)
-
-        # cls._propagate_allow_none_from_model(model, created_model)
 
         # As long as models are not created concurrently, setting the class members temporarily
         # should not have averse effects
@@ -457,7 +455,7 @@ class Model(GenericModel, Generic[RootT], metaclass=MyModelMetaclass):
             return json_content
 
     def from_json(self, json_contents: str) -> None:
-        new_model = self.parse_raw(json_contents, proto=pydantic_protocol.json)
+        new_model = self.parse_raw(json_contents, proto=PydanticProtocol.json)
         self.contents = new_model.contents
 
     def inner_type(self, with_args: bool = False) -> type | None:

--- a/src/omnipy/data/model.py
+++ b/src/omnipy/data/model.py
@@ -435,7 +435,7 @@ class Model(GenericModel, Generic[RootT], metaclass=MyModelMetaclass):
     def absorb_and_replace(self, other: 'Model'):
         self.from_data(other.to_data())
 
-    def to_json(self, pretty=False) -> str:
+    def to_json(self, pretty=True) -> str:
         json_content = self.json()
         if pretty:
             return self._pretty_print_json(json.loads(json_content))
@@ -475,7 +475,7 @@ class Model(GenericModel, Generic[RootT], metaclass=MyModelMetaclass):
     #     return self.__class__.create_from_json, (self.to_json(),)
 
     @classmethod
-    def to_json_schema(cls, pretty=False) -> str:
+    def to_json_schema(cls, pretty=True) -> str:
         schema = cls.schema()
 
         if pretty:

--- a/src/omnipy/data/model.py
+++ b/src/omnipy/data/model.py
@@ -432,6 +432,9 @@ class Model(GenericModel, Generic[RootT], metaclass=MyModelMetaclass):
     def from_data(self, value: object) -> None:
         self._validate_and_set_contents(value)
 
+    def absorb_and_replace(self, other: 'Model'):
+        self.from_data(other.to_data())
+
     def to_json(self, pretty=False) -> str:
         json_content = self.json()
         if pretty:

--- a/src/omnipy/hub/runtime.py
+++ b/src/omnipy/hub/runtime.py
@@ -22,7 +22,6 @@ from omnipy.engine.local import LocalRunner
 from omnipy.hub.entry import DataPublisher, RuntimeEntryPublisher
 from omnipy.hub.root_log import RootLogConfigEntryPublisher, RootLogObjects
 from omnipy.log.registry import RunStateRegistry
-from omnipy.modules import register_serializers
 from omnipy.modules.prefect.engine.prefect import PrefectEngine
 
 
@@ -48,9 +47,6 @@ class RuntimeObjects(RuntimeEntryPublisher):
     registry: IsRunStateRegistry = field(default_factory=RunStateRegistry)
     serializers: IsSerializerRegistry = field(default_factory=SerializerRegistry)
     root_log: IsRootLogObjects = field(default_factory=RootLogObjects)
-
-    def __post_init__(self):
-        register_serializers(self.serializers)
 
 
 @dataclass
@@ -116,16 +112,3 @@ class Runtime(DataPublisher):
 
     def _update_job_creator_engine(self, _item_changed: Any):
         self.objects.job_creator.set_engine(self._get_engine(self.config.engine))
-
-    def _create_serializer_registry(self):
-        from omnipy.modules.json.serializers import JsonDatasetToTarFileSerializer
-        from omnipy.modules.pandas.serializers import PandasDatasetToTarFileSerializer
-        from omnipy.modules.raw.serializers import RawDatasetToTarFileSerializer
-
-        registry = SerializerRegistry()
-
-        registry.register(PandasDatasetToTarFileSerializer)
-        registry.register(RawDatasetToTarFileSerializer)
-        registry.register(JsonDatasetToTarFileSerializer)
-
-        return registry

--- a/src/omnipy/hub/runtime.py
+++ b/src/omnipy/hub/runtime.py
@@ -11,6 +11,7 @@ from omnipy.api.protocols.public.config import (IsDataConfig,
                                                 IsLocalRunnerConfig,
                                                 IsPrefectEngineConfig,
                                                 IsRootLogConfig)
+from omnipy.api.protocols.public.data import IsSerializerRegistry
 from omnipy.api.protocols.public.hub import IsRootLogObjects, IsRuntimeConfig, IsRuntimeObjects
 from omnipy.compute.job import JobBase
 from omnipy.config.data import DataConfig
@@ -21,6 +22,7 @@ from omnipy.engine.local import LocalRunner
 from omnipy.hub.entry import DataPublisher, RuntimeEntryPublisher
 from omnipy.hub.root_log import RootLogConfigEntryPublisher, RootLogObjects
 from omnipy.log.registry import RunStateRegistry
+from omnipy.modules import register_serializers
 from omnipy.modules.prefect.engine.prefect import PrefectEngine
 
 
@@ -44,7 +46,11 @@ class RuntimeObjects(RuntimeEntryPublisher):
     local: IsEngine = field(default_factory=LocalRunner)
     prefect: IsEngine = field(default_factory=PrefectEngine)
     registry: IsRunStateRegistry = field(default_factory=RunStateRegistry)
+    serializers: IsSerializerRegistry = field(default_factory=SerializerRegistry)
     root_log: IsRootLogObjects = field(default_factory=RootLogObjects)
+
+    def __post_init__(self):
+        register_serializers(self.serializers)
 
 
 @dataclass

--- a/src/omnipy/modules/__init__.py
+++ b/src/omnipy/modules/__init__.py
@@ -1,2 +1,15 @@
+from omnipy.api.protocols.public.data import IsSerializerRegistry
+
+
+def register_serializers(registry: IsSerializerRegistry):
+    from .json.serializers import JsonDatasetToTarFileSerializer
+    from .pandas.serializers import PandasDatasetToTarFileSerializer
+    from .raw.serializers import RawDatasetToTarFileSerializer
+
+    registry.register(PandasDatasetToTarFileSerializer)
+    registry.register(RawDatasetToTarFileSerializer)
+    registry.register(JsonDatasetToTarFileSerializer)
+
+
 # TODO: Add module with helper classes/functions/takss to make it simpler to contact REST apis
 #       Augmentation service should have some attempts at this.

--- a/src/omnipy/modules/json/serializers.py
+++ b/src/omnipy/modules/json/serializers.py
@@ -35,8 +35,8 @@ class JsonDatasetToTarFileSerializer(TarFileSerializer):
         def json_decode_func(file_stream: IO[bytes]) -> str:
             return file_stream.read().decode('utf8')
 
-        def json_dictify_object(obj_type: str, obj_val: str) -> dict[str, str]:
-            return {f'{obj_type}': f'{obj_val}'}
+        def json_dictify_object(data_file: str, obj_val: str) -> dict[str, str]:
+            return {f'{data_file}': f'{obj_val}'}
 
         cls.create_dataset_from_tarfile(
             json_dataset,

--- a/src/omnipy/modules/pandas/serializers.py
+++ b/src/omnipy/modules/pandas/serializers.py
@@ -40,8 +40,8 @@ class PandasDatasetToTarFileSerializer(TarFileSerializer):
         def csv_decode_func(file_stream: IO[bytes]) -> pd.DataFrame:
             return pd.read_csv(file_stream, encoding='utf8')
 
-        def python_dictify_object(obj_type: str, obj_val: Any) -> dict:
-            return {obj_type: obj_val}
+        def python_dictify_object(data_file: str, obj_val: Any) -> dict:
+            return {data_file: obj_val}
 
         cls.create_dataset_from_tarfile(
             pandas_dataset,

--- a/src/omnipy/modules/raw/serializers.py
+++ b/src/omnipy/modules/raw/serializers.py
@@ -35,8 +35,8 @@ class RawDatasetToTarFileSerializer(TarFileSerializer):
         def raw_decode_func(file_stream: IO[bytes]) -> str:
             return file_stream.read().decode('utf8')
 
-        def python_dictify_object(obj_type: str, obj_val: Any) -> dict:
-            return {obj_type: obj_val}
+        def python_dictify_object(data_file: str, obj_val: Any) -> dict:
+            return {data_file: obj_val}
 
         cls.create_dataset_from_tarfile(
             dataset,

--- a/src/omnipy/util/helpers.py
+++ b/src/omnipy/util/helpers.py
@@ -16,7 +16,10 @@ from typing import (Annotated,
                     TypeVar,
                     Union)
 
+from isort import place_module
+from isort.sections import STDLIB
 from pydantic import ValidationError
+from pydantic.typing import display_as_type
 from typing_inspect import get_generic_bases, is_generic_type
 
 from omnipy.api.typedefs import LocaleType
@@ -143,6 +146,17 @@ def remove_annotated_plus_optional_if_present(
             else:
                 type_or_class = Union[args[:-1]]
     return type_or_class
+
+
+def remove_forward_ref_notation(type_str: str):
+    return type_str.replace("ForwardRef('", '').replace("')", '')
+
+
+def generate_qualname(cls_name: str, model: Any) -> str:
+    m_module = model.__module__ if hasattr(model, '__module__') else ''
+    m_module_prefix = f'{m_module}.' if m_module and place_module(m_module) != STDLIB else ''
+    fully_qual_model_name = f'{m_module_prefix}{display_as_type(model)}'
+    return f'{cls_name}[{fully_qual_model_name}]'
 
 
 class Snapshot(NamedTuple):

--- a/src/omnipy/util/helpers.py
+++ b/src/omnipy/util/helpers.py
@@ -105,7 +105,7 @@ def all_equals(first, second) -> bool:
     equals = first == second
     if is_iterable(equals):
         if hasattr(equals, 'all') and callable(getattr(equals, 'all')):
-            return equals.all()
+            return equals.all(None)  # works for both pandas and numpy
         else:
             return all(equals)
     else:

--- a/tests/data/helpers/functions.py
+++ b/tests/data/helpers/functions.py
@@ -4,11 +4,11 @@ from typing import Any, Callable
 
 
 def assert_tar_file_contents(tarfile_bytes: bytes,
-                             obj_type_name: str,
+                             data_file_name: str,
                              file_suffix: str,
                              decode_func: Callable,
                              exp_contents: Any):
     with tarfile.open(fileobj=BytesIO(tarfile_bytes), mode='r:gz') as tarfile_stream:
-        file_contents = tarfile_stream.extractfile(f'{obj_type_name}.{file_suffix}')
+        file_contents = tarfile_stream.extractfile(f'{data_file_name}.{file_suffix}')
         assert file_contents is not None
         assert decode_func(file_contents.read()) == exp_contents

--- a/tests/data/helpers/mocks.py
+++ b/tests/data/helpers/mocks.py
@@ -62,8 +62,8 @@ class MockNumberToTarFileSerializer(TarFileSerializer):
         def number_decode_func(file_stream: IO[bytes]) -> int:
             return int.from_bytes(file_stream.read(), byteorder=sys.byteorder)
 
-        def python_dictify_object(obj_type: str, obj_val: Any) -> dict:
-            return {obj_type: obj_val}
+        def python_dictify_object(data_file: str, obj_val: Any) -> dict:
+            return {data_file: obj_val}
 
         cls.create_dataset_from_tarfile(
             number_dataset,

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -376,8 +376,8 @@ def test_import_and_export():
       }
     }''')  # noqa: Q001
 
-    assert dataset.to_json() == dataset.to_json(pretty=False)  # noqa
-    assert dataset.to_json_schema() == dataset.to_json_schema(pretty=False)  # noqa
+    assert dataset.to_json() == dataset.to_json(pretty=True)  # noqa
+    assert dataset.to_json_schema() == dataset.to_json_schema(pretty=True)  # noqa
 
 
 def test_import_export_custom_parser_to_other_type():

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -186,17 +186,17 @@ def test_more_dict_methods_with_parsing():
 
 
 def test_equality() -> None:
-    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [1.0, 2.0, 3.0]}) == \
-           Dataset[Model[list[int]]]({'data_file_1': [1.0, 2.0, 3.0], 'data_file_2': [1, 2, 3]})
+    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [1.0, 2.0, 3.0]}) \
+           == Dataset[Model[list[int]]]({'data_file_1': [1.0, 2.0, 3.0], 'data_file_2': [1, 2, 3]})
 
-    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [1, 2, 3]}) != \
-           Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [3, 2, 1]})
+    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [1, 2, 3]}) \
+           != Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [3, 2, 1]})
 
-    assert Dataset[Model[list[int]]]({'1': [1, 2, 3]}) == \
-           Dataset[Model[list[int]]]({1: [1, 2, 3]})
+    assert Dataset[Model[list[int]]]({'1': [1, 2, 3]}) \
+           == Dataset[Model[list[int]]]({1: [1, 2, 3]})
 
-    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3]}) != \
-           Dataset[Model[list[float]]]({'data_file_1': [1.0, 2.0, 3.0]})
+    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3]}) \
+           != Dataset[Model[list[float]]]({'data_file_1': [1.0, 2.0, 3.0]})
 
 
 def test_complex_equality() -> None:
@@ -271,33 +271,33 @@ def test_qualname():
     assert Model[int].__qualname__ == 'Model[int]'
     assert Model[Model[int]].__qualname__ == 'Model[omnipy.data.model.Model[int]]'
     assert ParentDataset.__qualname__ == 'ParentGenericDataset[NumberModel]'
-    assert ParentDatasetNested.__qualname__ == 'ParentGenericDataset[Union[Model[str], NumberModel]]'
+    assert ParentDatasetNested.__qualname__ \
+           == 'ParentGenericDataset[Union[Model[str], NumberModel]]'
 
 
 def test_repr():
-    assert repr(Dataset[
-        Model[int]]) == "<class 'omnipy.data.dataset.Dataset[omnipy.data.model.Model[int]]'>"
+    assert repr(Dataset[Model[int]]) == \
+           "<class 'omnipy.data.dataset.Dataset[omnipy.data.model.Model[int]]'>"
     assert repr(Dataset[Model[int]](a=5, b=7)) == 'Dataset[Model[int]](a=5, b=7)'
     assert repr(Dataset[Model[int]]({'a': 5, 'b': 7})) == 'Dataset[Model[int]](a=5, b=7)'
     assert repr(Dataset[Model[int]](data={'a': 5, 'b': 7})) == 'Dataset[Model[int]](a=5, b=7)'
     assert repr(Dataset[Model[int]]([('a', 5), ('b', 7)])) == 'Dataset[Model[int]](a=5, b=7)'
     assert repr(Dataset[Model[int]](data=[('a', 5), ('b', 7)])) == 'Dataset[Model[int]](a=5, b=7)'
 
-    assert repr(Dataset[Model[Model[int]]]
-                ) == "<class 'omnipy.data.dataset.Dataset[omnipy.data.model.Model[Model[int]]]'>"
-    assert repr(Dataset[Model[Model[int]]](
-        a=Model[int](5))) == 'Dataset[Model[Model[int]]](a=Model[int](5))'
+    assert repr(Dataset[Model[Model[int]]]) \
+           == "<class 'omnipy.data.dataset.Dataset[omnipy.data.model.Model[Model[int]]]'>"
+    assert repr(Dataset[Model[Model[int]]](a=Model[int](5))) \
+           == 'Dataset[Model[Model[int]]](a=Model[int](5))'
 
-    assert repr(
-        ParentDataset) == "<class 'tests.data.test_dataset.ParentGenericDataset[NumberModel]'>"
-    assert repr(
-        ParentDataset(a=NumberModel(5))) == 'ParentGenericDataset[NumberModel](a=NumberModel(5))'
+    assert repr(ParentDataset) \
+           == "<class 'tests.data.test_dataset.ParentGenericDataset[NumberModel]'>"
+    assert repr(ParentDataset(a=NumberModel(5))) \
+           == 'ParentGenericDataset[NumberModel](a=NumberModel(5))'
 
-    assert repr(
-        ParentDatasetNested
-    ) == "<class 'tests.data.test_dataset.ParentGenericDataset[Union[Model[str], NumberModel]]'>"
-    assert repr(ParentDatasetNested(
-        a='abc')) == "ParentGenericDataset[Union[Model[str], NumberModel]](a=Model[str]('abc'))"
+    assert repr(ParentDatasetNested) == ("<class 'tests.data.test_dataset.ParentGenericDataset"
+                                         "[Union[Model[str], NumberModel]]'>")
+    assert repr(ParentDatasetNested(a='abc')) \
+           == "ParentGenericDataset[Union[Model[str], NumberModel]](a=Model[str]('abc'))"
 
 
 def test_basic_validation():

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -16,7 +16,7 @@ def test_no_model():
         Dataset()
 
     with pytest.raises(TypeError):
-        Dataset({'obj_type_1': 123, 'obj_type_2': 234})
+        Dataset({'file_1': 123, 'file_2': 234})
 
     with pytest.raises(TypeError):
 
@@ -39,49 +39,54 @@ def test_no_model():
 def test_init_with_basic_parsing():
     dataset_1 = Dataset[Model[int]]()
 
-    dataset_1['obj_type_1'] = 123
-    dataset_1['obj_type_2'] = 456
+    dataset_1['data_file_1'] = 123
+    dataset_1['data_file_2'] = 456
 
     assert len(dataset_1) == 2
-    assert dataset_1['obj_type_1'] == 123
-    assert dataset_1['obj_type_2'] == 456
+    assert dataset_1['data_file_1'] == Model[int](123)
+    assert dataset_1['data_file_2'].contents == 456
 
-    dataset_2 = Dataset[Model[int]]({'obj_type_1': 456.5, 'obj_type_2': '789', 'obj_type_3': True})
+    dataset_2 = Dataset[Model[int]]({
+        'data_file_1': 456.5, 'data_file_2': '789', 'data_file_3': True
+    })
 
     assert len(dataset_2) == 3
-    assert dataset_2['obj_type_1'] == 456
-    assert dataset_2['obj_type_2'] == 789
-    assert dataset_2['obj_type_3'] == 1
+    assert dataset_2['data_file_1'].contents == 456
+    assert dataset_2['data_file_2'].contents == 789
+    assert dataset_2['data_file_3'].contents == 1
 
-    dataset_3 = Dataset[Model[str]]([('obj_type_1', 'abc'), ('obj_type_2', 123),
-                                     ('obj_type_3', True)])
+    dataset_3 = Dataset[Model[str]]([('data_file_1', 'abc'), ('data_file_2', 123),
+                                     ('data_file_3', True)])
 
     assert len(dataset_3) == 3
-    assert dataset_3['obj_type_1'] == 'abc'
-    assert dataset_3['obj_type_2'] == '123'
-    assert dataset_3['obj_type_3'] == 'True'
+    assert dataset_3['data_file_1'].contents == 'abc'
+    assert dataset_3['data_file_2'].contents == '123'
+    assert dataset_3['data_file_3'].contents == 'True'
 
-    # TODO: Change most or all Dataset inits in tests and elsewhere to use this format. Also change
-    #       from 'obj_type' to 'file' everywhere.
-    dataset_4 = Dataset[Model[dict[int, int]]](file_1={1: 1234, 2: 2345}, file_2={2: 2345, 3: 3456})
+    dataset_4 = Dataset[Model[dict[int, int]]](
+        data_file_1={
+            1: 1234, 2: 2345
+        }, data_file_2={
+            2: 2345, 3: 3456
+        })
 
     assert len(dataset_4) == 2
-    assert dataset_4['file_1'] == {1: 1234, 2: 2345}
-    assert dataset_4['file_2'] == {2: 2345, 3: 3456}
+    assert dataset_4['data_file_1'].contents == {1: 1234, 2: 2345}
+    assert dataset_4['data_file_2'].contents == {2: 2345, 3: 3456}
 
 
 def test_init_errors():
     with pytest.raises(TypeError):
-        Dataset[Model[int]]({'file_1': 123}, {'file_2': 234})
+        Dataset[Model[int]]({'data_file_1': 123}, {'data_file_2': 234})
 
     with pytest.raises(AssertionError):
-        Dataset[Model[int]]({'file_1': 123}, data={'file_2': 234})
+        Dataset[Model[int]]({'data_file_1': 123}, data={'data_file_2': 234})
 
     with pytest.raises(AssertionError):
-        Dataset[Model[int]]({'file_1': 123}, file_2=234)
+        Dataset[Model[int]]({'data_file_1': 123}, data_file_2=234)
 
     with pytest.raises(AssertionError):
-        Dataset[Model[int]](data={'file_1': 123}, file_2=234)
+        Dataset[Model[int]](data={'data_file_1': 123}, data_file_2=234)
 
     with pytest.raises(ValidationError):
         Dataset[Model[int]](data=123)
@@ -134,45 +139,46 @@ def test_more_dict_methods_with_parsing():
     assert list(dataset_1.values()) == []
     assert list(dataset_1.items()) == []
 
-    dataset = Dataset[Model[str]]({'obj_type_1': 123, 'obj_type_2': 234})
+    dataset = Dataset[Model[str]]({'data_file_1': 123, 'data_file_2': 234})
 
-    assert list(dataset.keys()) == ['obj_type_1', 'obj_type_2']
-    assert list(dataset.values()) == ['123', '234']
-    assert list(dataset.items()) == [('obj_type_1', '123'), ('obj_type_2', '234')]
+    assert list(dataset.keys()) == ['data_file_1', 'data_file_2']
+    assert list(dataset.values()) == [Model[str]('123'), Model[str]('234')]
+    assert list(dataset.items()) == [('data_file_1', Model[str]('123')),
+                                     ('data_file_2', Model[str]('234'))]
 
-    dataset['obj_type_2'] = 345
+    dataset['data_file_2'] = 345
 
     assert len(dataset) == 2
-    assert dataset['obj_type_1'] == '123'
-    assert dataset['obj_type_2'] == '345'
+    assert dataset['data_file_1'].contents == '123'
+    assert dataset['data_file_2'].contents == '345'
 
-    del dataset['obj_type_1']
+    del dataset['data_file_1']
     assert len(dataset) == 1
-    assert dataset['obj_type_2'] == '345'
+    assert dataset['data_file_2'].contents == '345'
 
     with pytest.raises(KeyError):
-        assert dataset['obj_type_3']
+        assert dataset['data_file_3']
 
-    dataset.update({'obj_type_2': 456, 'obj_type_3': 567})
-    assert dataset['obj_type_2'] == '456'
-    assert dataset['obj_type_3'] == '567'
+    dataset.update({'data_file_2': 456, 'data_file_3': 567})
+    assert dataset['data_file_2'].contents == '456'
+    assert dataset['data_file_3'].contents == '567'
 
-    dataset.setdefault('obj_type_3', 789)
-    assert dataset.get('obj_type_3') == '567'
+    dataset.setdefault('data_file_3', 789)
+    assert dataset.get('data_file_3').contents == '567'
 
-    dataset.setdefault('obj_type_4', 789)
-    assert dataset.get('obj_type_4') == '789'
+    dataset.setdefault('data_file_4', 789)
+    assert dataset.get('data_file_4').contents == '789'
 
     assert len(dataset) == 3
 
-    dataset.pop('obj_type_3')
+    dataset.pop('data_file_3')
     assert len(dataset) == 2
 
     # UserDict() implementation of popitem pops items FIFO contrary of the LIFO specified
     # in the standard library: https://docs.python.org/3/library/stdtypes.html#dict.popitem
     dataset.popitem()
     assert len(dataset) == 1
-    assert dataset.to_data() == {'obj_type_4': '789'}
+    assert dataset.to_data() == {'data_file_4': '789'}
 
     dataset.clear()
     assert len(dataset) == 0
@@ -180,17 +186,17 @@ def test_more_dict_methods_with_parsing():
 
 
 def test_equality() -> None:
-    assert Dataset[Model[list[int]]]({'file_1': [1, 2, 3], 'file_2': [1.0, 2.0, 3.0]}) == \
-           Dataset[Model[list[int]]]({'file_1': [1.0, 2.0, 3.0], 'file_2': [1, 2, 3]})
+    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [1.0, 2.0, 3.0]}) == \
+           Dataset[Model[list[int]]]({'data_file_1': [1.0, 2.0, 3.0], 'data_file_2': [1, 2, 3]})
 
-    assert Dataset[Model[list[int]]]({'file_1': [1, 2, 3], 'file_2': [1, 2, 3]}) != \
-           Dataset[Model[list[int]]]({'file_1': [1, 2, 3], 'file_2': [3, 2, 1]})
+    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [1, 2, 3]}) != \
+           Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3], 'data_file_2': [3, 2, 1]})
 
     assert Dataset[Model[list[int]]]({'1': [1, 2, 3]}) == \
            Dataset[Model[list[int]]]({1: [1, 2, 3]})
 
-    assert Dataset[Model[list[int]]]({'file_1': [1, 2, 3]}) != \
-           Dataset[Model[list[float]]]({'file_1': [1.0, 2.0, 3.0]})
+    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3]}) != \
+           Dataset[Model[list[float]]]({'data_file_1': [1.0, 2.0, 3.0]})
 
 
 def test_complex_equality() -> None:
@@ -200,32 +206,32 @@ def test_complex_equality() -> None:
     class MyInt(Model[int]):
         ...
 
-    assert Dataset[Model[list[int]]]({'file_1': [1, 2, 3]}) != \
-           Dataset[MyIntList]({'file_1': [1, 2, 3]})
+    assert Dataset[Model[list[int]]]({'data_file_1': [1, 2, 3]}) != \
+           Dataset[MyIntList]({'data_file_1': [1, 2, 3]})
 
-    assert Dataset[Model[MyIntList]]({'file_1': [1, 2, 3]}) == \
-           Dataset[Model[MyIntList]]({'file_1': MyIntList([1, 2, 3])})
+    assert Dataset[Model[MyIntList]]({'data_file_1': [1, 2, 3]}) == \
+           Dataset[Model[MyIntList]]({'data_file_1': MyIntList([1, 2, 3])})
 
-    assert Dataset[Model[list[MyInt]]]({'file_1': [1, 2, 3]}) == \
-           Dataset[Model[list[MyInt]]]({'file_1': list[MyInt]([1, 2, 3])})
+    assert Dataset[Model[list[MyInt]]]({'data_file_1': [1, 2, 3]}) == \
+           Dataset[Model[list[MyInt]]]({'data_file_1': list[MyInt]([1, 2, 3])})
 
-    assert Dataset[Model[list[MyInt]]]({'file_1': [1, 2, 3]}) != \
-           Dataset[Model[List[MyInt]]]({'file_1': [1, 2, 3]})
+    assert Dataset[Model[list[MyInt]]]({'data_file_1': [1, 2, 3]}) != \
+           Dataset[Model[List[MyInt]]]({'data_file_1': [1, 2, 3]})
 
     # Had to be set to dict to trigger difference in data contents. Validation for some reason
     # harmonised the data contents to list[MyInt] even though the model itself keeps the data
     # as MyIntList if provided in that form
-    as_list_of_myints_dataset = Dataset[Model[MyIntList | list[MyInt]]]({'file_1': [1, 2, 3]})
+    as_list_of_myints_dataset = Dataset[Model[MyIntList | list[MyInt]]]({'data_file_1': [1, 2, 3]})
     as_myintlist_dataset = Dataset[Model[MyIntList | list[MyInt]]]()
-    as_myintlist_dataset.data['file_1'] = MyIntList([1, 2, 3])
+    as_myintlist_dataset.data['data_file_1'] = MyIntList([1, 2, 3])
 
     assert as_list_of_myints_dataset != as_myintlist_dataset
 
-    assert Dataset[Model[MyIntList | list[MyInt]]]({'file_1': [1, 2, 3]}) == \
-           Dataset[Model[Union[MyIntList, list[MyInt]]]]({'file_1': [1, 2, 3]})
+    assert Dataset[Model[MyIntList | list[MyInt]]]({'data_file_1': [1, 2, 3]}) == \
+           Dataset[Model[Union[MyIntList, list[MyInt]]]]({'data_file_1': [1, 2, 3]})
 
-    assert Dataset[Model[MyIntList | list[MyInt]]]({'file_1': [1, 2, 3]}).to_data() == \
-           Dataset[Model[MyIntList | list[MyInt]]]({'file_1': MyIntList([1, 2, 3])}).to_data()
+    assert Dataset[Model[MyIntList | list[MyInt]]]({'data_file_1': [1, 2, 3]}).to_data() == \
+           Dataset[Model[MyIntList | list[MyInt]]]({'data_file_1': MyIntList([1, 2, 3])}).to_data()
 
 
 def test_equality_with_pydantic() -> None:
@@ -235,20 +241,20 @@ def test_equality_with_pydantic() -> None:
     class EqualPydanticModel(BaseModel):
         a: int = 0
 
-    assert Dataset[Model[PydanticModel]]({'file_1': {'a': 1}}) == \
-           Dataset[Model[PydanticModel]]({'file_1': {'a': 1.0}})
+    assert Dataset[Model[PydanticModel]]({'data_file_1': {'a': 1}}) == \
+           Dataset[Model[PydanticModel]]({'data_file_1': {'a': 1.0}})
 
-    assert Dataset[Model[PydanticModel]]({'file_1': {'a': 1}}) != \
-           Dataset[Model[EqualPydanticModel]]({'file_1': {'a': 1}})
+    assert Dataset[Model[PydanticModel]]({'data_file_1': {'a': 1}}) != \
+           Dataset[Model[EqualPydanticModel]]({'data_file_1': {'a': 1}})
 
 
 def test_basic_validation():
     dataset_1 = Dataset[Model[PositiveInt]]()
 
-    dataset_1['obj_type_1'] = 123
+    dataset_1['data_file_1'] = 123
 
     with pytest.raises(ValueError):
-        dataset_1['obj_type_2'] = -234
+        dataset_1['data_file_2'] = -234
 
     with pytest.raises(ValueError):
         Dataset[Model[list[StrictInt]]]([12.4, 11])  # noqa
@@ -257,85 +263,85 @@ def test_basic_validation():
 def test_import_and_export():
     dataset = Dataset[Model[dict[str, str]]]()
 
-    data = {'obj_type_1': {'a': 123, 'b': 234, 'c': 345}, 'obj_type_2': {'c': 456}}
+    data = {'data_file_1': {'a': 123, 'b': 234, 'c': 345}, 'data_file_2': {'c': 456}}
     dataset.from_data(data)
 
-    assert dataset['obj_type_1'] == {'a': '123', 'b': '234', 'c': '345'}
-    assert dataset['obj_type_2'] == {'c': '456'}
+    assert dataset['data_file_1'].contents == {'a': '123', 'b': '234', 'c': '345'}
+    assert dataset['data_file_2'].contents == {'c': '456'}
 
     assert dataset.to_data() == {
-        'obj_type_1': {
+        'data_file_1': {
             'a': '123', 'b': '234', 'c': '345'
-        }, 'obj_type_2': {
+        }, 'data_file_2': {
             'c': '456'
         }
     }
 
     assert dataset.to_json(pretty=False) == {
-        'obj_type_1': '{"a": "123", "b": "234", "c": "345"}', 'obj_type_2': '{"c": "456"}'
+        'data_file_1': '{"a": "123", "b": "234", "c": "345"}', 'data_file_2': '{"c": "456"}'
     }
     assert dataset.to_json(pretty=True) == {
-        'obj_type_1':
+        'data_file_1':
             dedent("""\
             {
               "a": "123",
               "b": "234",
               "c": "345"
             }"""),
-        'obj_type_2':
+        'data_file_2':
             dedent("""\
             {
               "c": "456"
             }""")
     }
 
-    data = {'obj_type_1': {'a': 333, 'b': 555, 'c': 777}, 'obj_type_3': {'a': '99', 'b': '98'}}
+    data = {'data_file_1': {'a': 333, 'b': 555, 'c': 777}, 'data_file_3': {'a': '99', 'b': '98'}}
     dataset.from_data(data)
 
     assert dataset.to_data() == {
-        'obj_type_1': {
+        'data_file_1': {
             'a': '333', 'b': '555', 'c': '777'
         },
-        'obj_type_2': {
+        'data_file_2': {
             'c': '456'
         },
-        'obj_type_3': {
+        'data_file_3': {
             'a': '99', 'b': '98'
         }
     }
 
-    data = {'obj_type_1': {'a': 167, 'b': 761}}
+    data = {'data_file_1': {'a': 167, 'b': 761}}
     dataset.from_data(data, update=False)
 
     assert dataset.to_data() == {
-        'obj_type_1': {
+        'data_file_1': {
             'a': '167', 'b': '761'
         },
     }
 
-    json_import = {'obj_type_2': '{"a": 987, "b": 654}'}
+    json_import = {'data_file_2': '{"a": 987, "b": 654}'}
 
     dataset.from_json(json_import)
     assert dataset.to_data() == {
-        'obj_type_1': {
+        'data_file_1': {
             'a': '167', 'b': '761'
-        }, 'obj_type_2': {
+        }, 'data_file_2': {
             'a': '987', 'b': '654'
         }
     }
 
     dataset.from_json(json_import, update=False)
-    assert dataset.to_data() == {'obj_type_2': {'a': '987', 'b': '654'}}
+    assert dataset.to_data() == {'data_file_2': {'a': '987', 'b': '654'}}
 
     json_import = (
-        ('obj_type_2', '{"a": 987, "b": 654}'),
-        ('obj_type_3', '{"b": 222, "c": 333}'),
+        ('data_file_2', '{"a": 987, "b": 654}'),
+        ('data_file_3', '{"b": 222, "c": 333}'),
     )
     dataset.from_json(json_import)
     assert dataset.to_data() == {
-        'obj_type_2': {
+        'data_file_2': {
             'a': '987', 'b': '654'
-        }, 'obj_type_3': {
+        }, 'data_file_3': {
             'b': '222', 'c': '333'
         }
     }
@@ -377,18 +383,18 @@ def test_import_and_export():
 def test_import_export_custom_parser_to_other_type():
     dataset = Dataset[StringToLength]()
 
-    dataset['obj_type_1'] = 'And we lived beneath the waves'
-    assert dataset['obj_type_1'] == 30
+    dataset['data_file_1'] = 'And we lived beneath the waves'
+    assert dataset['data_file_1'].contents == 30
 
-    dataset.from_data({'obj_type_2': 'In our yellow submarine'}, update=True)  # noqa
-    assert dataset['obj_type_1'] == 30
-    assert dataset['obj_type_2'] == 23
-    assert dataset.to_data() == {'obj_type_1': 30, 'obj_type_2': 23}
+    dataset.from_data({'data_file_2': 'In our yellow submarine'}, update=True)  # noqa
+    assert dataset['data_file_1'].contents == 30
+    assert dataset['data_file_2'].contents == 23
+    assert dataset.to_data() == {'data_file_1': 30, 'data_file_2': 23}
 
-    dataset.from_json({'obj_type_2': '"In our yellow submarine!"'}, update=True)  # noqa
-    assert dataset['obj_type_1'] == 30
-    assert dataset['obj_type_2'] == 24
-    assert dataset.to_json() == {'obj_type_1': '30', 'obj_type_2': '24'}
+    dataset.from_json({'data_file_2': '"In our yellow submarine!"'}, update=True)  # noqa
+    assert dataset['data_file_1'].contents == 30
+    assert dataset['data_file_2'].contents == 24
+    assert dataset.to_json() == {'data_file_1': '30', 'data_file_2': '24'}
 
     assert dataset.to_json_schema(pretty=True) == dedent('''\
     {
@@ -423,8 +429,8 @@ def test_generic_dataset_unbound_typevar():
     # Without further restrictions
 
     assert MyTupleOrListDataset().to_data() == {}
-    assert MyTupleOrListDataset({'a': (123, 'a')})['a'] == (123, 'a')
-    assert MyTupleOrListDataset({'a': [True, False]})['a'] == [True, False]
+    assert MyTupleOrListDataset({'a': (123, 'a')})['a'].contents == (123, 'a')
+    assert MyTupleOrListDataset({'a': [True, False]})['a'].contents == [True, False]
 
     with pytest.raises(ValidationError):
         MyTupleOrListDataset({'a': 123})
@@ -437,8 +443,8 @@ def test_generic_dataset_unbound_typevar():
 
     # Restricting the contents of the tuples and lists
 
-    assert MyTupleOrListDataset[int]({'a': (123, '456')})['a'] == (123, 456)
-    assert MyTupleOrListDataset[bool]({'a': [False, 1, '0']})['a'] == [False, True, False]
+    assert MyTupleOrListDataset[int]({'a': (123, '456')})['a'].contents == (123, 456)
+    assert MyTupleOrListDataset[bool]({'a': [False, 1, '0']})['a'].contents == [False, True, False]
 
     with pytest.raises(ValidationError):
         MyTupleOrListDataset[int]({'a': (123, 'abc')})
@@ -462,8 +468,8 @@ def test_generic_dataset_bound_typevar():
 
     assert MyListOfIntsOrStringsDataset().to_data() == {}
 
-    assert MyListOfIntsOrStringsDataset({'a': (123, 'a')})['a'] == [123, 'a']
-    assert MyListOfIntsOrStringsDataset({'a': [True, False]})['a'] == [1, 0]
+    assert MyListOfIntsOrStringsDataset({'a': (123, 'a')})['a'].contents == [123, 'a']
+    assert MyListOfIntsOrStringsDataset({'a': [True, False]})['a'].contents == [1, 0]
 
     with pytest.raises(ValidationError):
         MyListOfIntsOrStringsDataset({'a': 123})
@@ -475,8 +481,8 @@ def test_generic_dataset_bound_typevar():
         MyListOfIntsOrStringsDataset({'a': {'x': 123}})
 
     # Further restricting the contents of the tuples and lists
-    assert MyListOfIntsOrStringsDataset[str]({'a': (123, '456')})['a'] == ['123', '456']
-    assert MyListOfIntsOrStringsDataset[int]({'a': (123, '456')})['a'] == [123, 456]
+    assert MyListOfIntsOrStringsDataset[str]({'a': (123, '456')})['a'].contents == ['123', '456']
+    assert MyListOfIntsOrStringsDataset[int]({'a': (123, '456')})['a'].contents == [123, 456]
 
     with pytest.raises(ValidationError):
         MyListOfIntsOrStringsDataset[int]({'a': (123, 'abc')})
@@ -579,7 +585,7 @@ def test_complex_models():
         dataset.from_data([(i, [0, i]) for i in range(0, 5)])  # noqa
 
     dataset.from_data([(i, [1, i]) for i in range(1, 5)])  # noqa
-    assert dataset['4'] == [4, 3, 2, 1]
+    assert dataset['4'].contents == [4, 3, 2, 1]
 
     assert dataset.to_data() == {'1': [1], '2': [2, 1], '3': [3, 2, 1], '4': [4, 3, 2, 1]}
 

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -240,8 +240,8 @@ def test_repr():
     assert repr(Model[int]) == "<class 'omnipy.data.model.Model[int]'>"
     assert repr(Model[int](5)) == 'Model[int](5)'
 
-    assert repr(
-        Model[Model[int]]) == "<class 'omnipy.data.model.Model[omnipy.data.model.Model[int]]'>"
+    assert repr(Model[Model[int]]) \
+           == "<class 'omnipy.data.model.Model[omnipy.data.model.Model[int]]'>"
     assert repr(Model[Model[int]](Model[int](5))) == 'Model[Model[int]](Model[int](5))'
 
     assert repr(ParentModel) == "<class 'tests.data.test_model.ParentGenericModel[NumberModel]'>"

--- a/tests/data/test_model.py
+++ b/tests/data/test_model.py
@@ -936,8 +936,8 @@ def test_import_export_methods():
 
     assert Model[int](12).to_json() == '12'
     assert Model[str]('test').to_json() == '"test"'
-    assert Model[dict]({'a': 2}).to_json() == '{"a": 2}'
-    assert Model[list]([2, 4, 'b']).to_json() == '[2, 4, "b"]'
+    assert Model[dict]({'a': 2}).to_json(pretty=False) == '{"a": 2}'
+    assert Model[list]([2, 4, 'b']).to_json(pretty=False) == '[2, 4, "b"]'
 
     model_int = Model[int]()
     model_int.from_json('12')
@@ -985,28 +985,28 @@ def test_import_export_methods():
     assert model_list.to_data() == [True, 'text', -47.9]
 
     std_description = Model._get_standard_field_description()
-    assert Model[int].to_json_schema(pretty=True) == dedent('''\
+    assert Model[int].to_json_schema() == dedent('''\
     {
       "title": "Model[int]",
       "description": "''' + std_description + '''",
       "type": "integer"
     }''')  # noqa: Q001
 
-    assert Model[str].to_json_schema(pretty=True) == dedent('''\
+    assert Model[str].to_json_schema() == dedent('''\
     {
       "title": "Model[str]",
       "description": "''' + std_description + '''",
       "type": "string"
     }''')  # noqa: Q001
 
-    assert Model[dict].to_json_schema(pretty=True) == dedent('''\
+    assert Model[dict].to_json_schema() == dedent('''\
     {
       "title": "Model[dict]",
       "description": "''' + std_description + '''",
       "type": "object"
     }''')  # noqa: Q001
 
-    assert Model[list].to_json_schema(pretty=True) == dedent('''\
+    assert Model[list].to_json_schema() == dedent('''\
     {
       "title": "Model[list]",
       "description": "''' + std_description + '''",
@@ -1494,8 +1494,9 @@ def test_nested_model():
     model_1.from_data(unloaded_data)
     assert model_1.to_data() == unloaded_data
 
-    assert model_1.to_json() == ('{"2": [2], "3": [3], "4": [2, 2], "5": [5], "6": [2, 3], '
-                                 '"7": [7], "8": [2, 2, 2], "9": [3, 3], "10": [2, 5]}')
+    assert model_1.to_json(
+        pretty=False) == ('{"2": [2], "3": [3], "4": [2, 2], "5": [5], "6": [2, 3], '
+                          '"7": [7], "8": [2, 2, 2], "9": [3, 3], "10": [2, 5]}')
 
     model_2 = DictToListOfPositiveInts()
     model_2.from_json('{"2": [2], "3": [3], "4": [2, 2], "5": [5], "6": [2, 3], '
@@ -1504,7 +1505,7 @@ def test_nested_model():
         2: [2], 3: [3], 4: [2, 2], 5: [5], 6: [2, 3], 7: [7], 8: [2, 2, 2], 9: [3, 3], 10: [2, 5]
     })
 
-    assert model_1.to_json_schema(pretty=True) == dedent("""\
+    assert model_1.to_json_schema() == dedent("""\
     {
       "title": "DictToListOfPositiveInts",
       "description": "This model is perfect for a mapping product numbers to factor lists",
@@ -1575,10 +1576,10 @@ def test_complex_nested_models():
     roman_tuple_model = ListOfProductFactorsTuplesRoman(unloaded_data)
     roman_dict_model_1 = ProductFactorDictInRomanNumerals(roman_tuple_model.to_data())
 
-    assert roman_dict_model_1.to_json() == (
-        '{"II": ["II"], "III": ["III"], "IV": ["II", "II"], "V": ["V"], '
-        '"VI": ["II", "III"], "VII": ["VII"], "VIII": ["II", "II", "II"], '
-        '"IX": ["III", "III"], "X": ["II", "V"]}')
+    assert roman_dict_model_1.to_json(
+        pretty=False) == ('{"II": ["II"], "III": ["III"], "IV": ["II", "II"], "V": ["V"], '
+                          '"VI": ["II", "III"], "VII": ["VII"], "VIII": ["II", "II", "II"], '
+                          '"IX": ["III", "III"], "X": ["II", "V"]}')
 
     roman_dict_model_2 = ProductFactorDictInRomanNumerals()
     roman_dict_model_2.from_json('{"II": ["II"], "III": ["III"], "IV": ["II", "II"], "V": ["V"], '
@@ -1596,7 +1597,7 @@ def test_complex_nested_models():
         'X': ['II', 'V']
     }
 
-    assert roman_dict_model_1.to_json_schema(pretty=True) == dedent("""\
+    assert roman_dict_model_1.to_json_schema() == dedent("""\
     {
       "title": "ProductFactorDictInRomanNumerals",
       "description": "Extremely useful model",

--- a/tests/data/test_serializer.py
+++ b/tests/data/test_serializer.py
@@ -11,15 +11,15 @@ from .helpers.mocks import MockNumberSerializer, MockNumberToTarFileSerializer, 
 def test_number_dataset_serializer():
     number_data = Dataset[Model[int]]()
 
-    number_data['obj_type1'] = 35
-    number_data['obj_type2'] = 12
+    number_data['data_file_1'] = 35
+    number_data['data_file_2'] = 12
 
     serializer = MockNumberSerializer()
 
     assert serializer.get_dataset_cls_for_new() is NumberDataset
 
     serialized_bytes = serializer.serialize(number_data)
-    assert serialized_bytes == b'obj_type1:35,obj_type2:12'
+    assert serialized_bytes == b'data_file_1:35,data_file_2:12'
 
     deserialized_obj = serializer.deserialize(serialized_bytes)
     assert deserialized_obj.to_data() == number_data.to_data()
@@ -29,8 +29,8 @@ def test_number_dataset_serializer():
 def test_number_dataset_to_tar_file_serializer():
     number_data = NumberDataset()
 
-    number_data['obj_type1'] = 35
-    number_data['obj_type2'] = 12
+    number_data['data_file_1'] = 35
+    number_data['data_file_2'] = 12
 
     serializer = MockNumberToTarFileSerializer()
 
@@ -39,8 +39,8 @@ def test_number_dataset_to_tar_file_serializer():
     tarfile_bytes = serializer.serialize(number_data)
     decode_func = lambda x: int.from_bytes(x, byteorder=sys.byteorder)  # noqa
 
-    assert_tar_file_contents(tarfile_bytes, 'obj_type1', 'num', decode_func, 35)
-    assert_tar_file_contents(tarfile_bytes, 'obj_type2', 'num', decode_func, 12)
+    assert_tar_file_contents(tarfile_bytes, 'data_file_1', 'num', decode_func, 35)
+    assert_tar_file_contents(tarfile_bytes, 'data_file_2', 'num', decode_func, 12)
 
     deserialized_json_data = serializer.deserialize(tarfile_bytes)
 

--- a/tests/hub/test_runtime.py
+++ b/tests/hub/test_runtime.py
@@ -10,6 +10,7 @@ from omnipy.api.enums import (ConfigOutputStorageProtocolOptions,
                               EngineChoice)
 from omnipy.api.protocols.public.hub import IsRuntime
 from omnipy.config.data import DataConfig
+from omnipy.data.serializer import SerializerRegistry
 from omnipy.hub.runtime import RuntimeConfig, RuntimeObjects
 
 from .helpers.mocks import (MockJobConfig,
@@ -72,6 +73,7 @@ def _assert_runtime_objects_default(objects: RuntimeObjects, config: RuntimeConf
     assert isinstance(objects.prefect, PrefectEngine)
 
     assert isinstance(objects.registry, RunStateRegistry)
+    assert isinstance(objects.serializers, SerializerRegistry)
 
 
 def test_config_default(teardown_rm_root_log_dir: Annotated[None, pytest.fixture]) -> None:

--- a/tests/integration/novel/full/test_multi_model_dataset.py
+++ b/tests/integration/novel/full/test_multi_model_dataset.py
@@ -44,11 +44,11 @@ def test_dataset_with_multiple_table_models():
 
     my_dataset.set_model('c', TableTemplate[MyOtherRecordSchema])
     assert my_dataset.get_model('c') == TableTemplate[MyOtherRecordSchema]
-    assert my_dataset['c'] == []
+    assert my_dataset['c'].contents == []
 
     with pytest.raises(ValidationError):
         my_dataset['c'] = [{'b': 'sd', 'd': False}, {'b': 'dd', 'd': False}]
-    assert my_dataset['c'] == []
+    assert my_dataset['c'].contents == []
     my_dataset['c'] = [{'b': 'sd', 'c': False}, {'b': 'dd', 'c': False}]
 
     del my_dataset['b']

--- a/tests/modules/json/test_json.py
+++ b/tests/modules/json/test_json.py
@@ -6,64 +6,64 @@ from omnipy.modules.json.datasets import JsonDataset
 
 def test_json_dataset_array_of_objects_same_keys():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '[{"a": "abc", "b": 12}, {"a": "bcd", "b": 23}]'})
-    assert json_data.to_data() == dict(obj_type=[{'a': 'abc', 'b': 12}, {'a': 'bcd', 'b': 23}])
+    json_data.from_json({'data_file': '[{"a": "abc", "b": 12}, {"a": "bcd", "b": 23}]'})
+    assert json_data.to_data() == dict(data_file=[{'a': 'abc', 'b': 12}, {'a': 'bcd', 'b': 23}])
 
 
 def test_json_dataset_array_of_objects_different_keys():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '[{"a": "abc", "b": 12}, {"c": "bcd"}]'})
-    assert json_data.to_data() == dict(obj_type=[{'a': 'abc', 'b': 12}, {'c': 'bcd'}])
+    json_data.from_json({'data_file': '[{"a": "abc", "b": 12}, {"c": "bcd"}]'})
+    assert json_data.to_data() == dict(data_file=[{'a': 'abc', 'b': 12}, {'c': 'bcd'}])
 
 
 def test_json_dataset_array_of_nested_objects():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '[{"a": "abc", "b": {"c": [1, 3]}}]'})
-    assert json_data.to_data() == dict(obj_type=[{'a': 'abc', 'b': {'c': [1, 3]}}])
+    json_data.from_json({'data_file': '[{"a": "abc", "b": {"c": [1, 3]}}]'})
+    assert json_data.to_data() == dict(data_file=[{'a': 'abc', 'b': {'c': [1, 3]}}])
 
 
 def test_json_dataset_empty_array():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '[]'})
-    assert json_data.to_data() == dict(obj_type=[])
+    json_data.from_json({'data_file': '[]'})
+    assert json_data.to_data() == dict(data_file=[])
 
 
 def test_json_dataset_empty_object():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '[{"a": "abc", "b": 12}, {}]'})
-    assert json_data.to_data() == dict(obj_type=[{'a': 'abc', 'b': 12}, {}])
+    json_data.from_json({'data_file': '[{"a": "abc", "b": 12}, {}]'})
+    assert json_data.to_data() == dict(data_file=[{'a': 'abc', 'b': 12}, {}])
 
 
 def test_json_dataset_single_number():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '1'})
-    assert json_data.to_data() == dict(obj_type=1)
+    json_data.from_json({'data_file': '1'})
+    assert json_data.to_data() == dict(data_file=1)
 
 
 def test_json_dataset_list_of_scalars():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '[true, 234, 2.0, "12", null]'})
-    assert json_data.to_data() == dict(obj_type=[True, 234, 2.0, '12', None])
+    json_data.from_json({'data_file': '[true, 234, 2.0, "12", null]'})
+    assert json_data.to_data() == dict(data_file=[True, 234, 2.0, '12', None])
 
 
 def test_json_dataset_nested():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': '{"a": {"b": [[true, 234, 2.0, "12", null], "c"]}}'})
-    assert json_data.to_data() == dict(obj_type={'a': {'b': [[True, 234, 2.0, '12', None], 'c']}})
+    json_data.from_json({'data_file': '{"a": {"b": [[true, 234, 2.0, "12", null], "c"]}}'})
+    assert json_data.to_data() == dict(data_file={'a': {'b': [[True, 234, 2.0, '12', None], 'c']}})
 
 
 def test_json_dataset_empty_array_with_whitespace():
     json_data = JsonDataset()
-    json_data.from_json({'obj_type': ' [] '})
+    json_data.from_json({'data_file': ' [] '})
 
 
 def test_fail_json_dataset_no_json():
     json_data = JsonDataset()
     with pytest.raises(ValidationError):
-        json_data.from_json({'obj_type': ''})
+        json_data.from_json({'data_file': ''})
 
 
 def test_fail_json_dataset_malformed_json():
     json_data = JsonDataset()
     with pytest.raises(ValidationError):
-        json_data.from_json({'obj_type': '[{,'})
+        json_data.from_json({'data_file': '[{,'})

--- a/tests/modules/json/test_serialize_json.py
+++ b/tests/modules/json/test_serialize_json.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 from omnipy.data.serializer import TarFileSerializer
 from omnipy.modules.json.datasets import JsonDataset
 from omnipy.modules.json.serializers import JsonDatasetToTarFileSerializer
@@ -7,28 +9,30 @@ from ...data.helpers.functions import assert_tar_file_contents
 
 def test_json_dataset_serializer_to_tar_file():
     json_data = JsonDataset()
-    obj_type_1_json = """
-[
-  {
-    "a": "abc",
-    "b": 12
-  },
-  {
-    "a": "bcd",
-    "b": 23
-  }
-]"""[1:]
-    obj_type_2_json = """
-[
-  {
-    "a": "abc",
-    "b": 12
-  },
-  {
-    "c": "bcd"
-  }
-]"""[1:]
-    json_data.from_json({'obj_type.1': f'{obj_type_1_json}', 'obj_type.2': f'{obj_type_2_json}'})
+    data_file_1_json = dedent("""\
+        [
+          {
+            "a": "abc",
+            "b": 12
+          },
+          {
+            "a": "bcd",
+            "b": 23
+          }
+        ]""")
+    data_file_2_json = dedent("""\
+        [
+          {
+            "a": "abc",
+            "b": 12
+          },
+          {
+            "c": "bcd"
+          }
+        ]""")
+    json_data.from_json({
+        'data_file_1': f'{data_file_1_json}', 'data_file_2': f'{data_file_2_json}'
+    })
 
     serializer = JsonDatasetToTarFileSerializer()
     assert serializer.get_dataset_cls_for_new() is JsonDataset
@@ -37,8 +41,8 @@ def test_json_dataset_serializer_to_tar_file():
     tarfile_bytes = serializer.serialize(json_data)
     decode_func = lambda x: x.decode('utf8')  # noqa
 
-    assert_tar_file_contents(tarfile_bytes, 'obj_type.1', 'json', decode_func, obj_type_1_json)
-    assert_tar_file_contents(tarfile_bytes, 'obj_type.2', 'json', decode_func, obj_type_2_json)
+    assert_tar_file_contents(tarfile_bytes, 'data_file_1', 'json', decode_func, data_file_1_json)
+    assert_tar_file_contents(tarfile_bytes, 'data_file_2', 'json', decode_func, data_file_2_json)
 
     deserialized_json_data = serializer.deserialize(tarfile_bytes)
 

--- a/tests/modules/pandas/test_pandas.py
+++ b/tests/modules/pandas/test_pandas.py
@@ -14,10 +14,10 @@ from .util import assert_pandas_frame_dtypes
 
 def test_pandas_dataset_list_of_objects_same_keys():
     pandas_data = PandasDataset()
-    data = {'obj_type': [{'a': 'abc', 'b': 12}, {'a': 'bcd', 'b': 23}]}
+    data = {'data_file': [{'a': 'abc', 'b': 12}, {'a': 'bcd', 'b': 23}]}
     pandas_data.from_data(data)
     pd.testing.assert_frame_equal(
-        pandas_data['obj_type'],
+        pandas_data['data_file'].contents,
         pd.DataFrame([{
             'a': 'abc', 'b': 12
         }, {
@@ -25,16 +25,16 @@ def test_pandas_dataset_list_of_objects_same_keys():
         }]),
         check_dtype=False,
     )
-    assert_pandas_frame_dtypes(pandas_data['obj_type'], ('string', 'Int64'))
+    assert_pandas_frame_dtypes(pandas_data['data_file'], ('string', 'Int64'))
     assert pandas_data.to_data() == data
 
 
 def test_pandas_dataset_json_list_of_objects_same_keys():
     pandas_data = PandasDataset()
-    json_data = {'obj_type': '[{"a": "abc", "b": 12}, {"a": "bcd", "b": 23}]'}
+    json_data = {'data_file': '[{"a": "abc", "b": 12}, {"a": "bcd", "b": 23}]'}
     pandas_data.from_json(json_data)
     pd.testing.assert_frame_equal(
-        pandas_data['obj_type'],
+        pandas_data['data_file'].contents,
         pd.DataFrame([{
             'a': 'abc', 'b': 12
         }, {
@@ -42,16 +42,16 @@ def test_pandas_dataset_json_list_of_objects_same_keys():
         }]),
         check_dtype=False,
     )
-    assert_pandas_frame_dtypes(pandas_data['obj_type'], ('string', 'Int64'))
+    assert_pandas_frame_dtypes(pandas_data['data_file'], ('string', 'Int64'))
     assert pandas_data.to_json() == json_data
 
 
 def test_pandas_dataset_list_of_objects_different_keys():
     pandas_data = PandasDataset()
-    data = {'obj_type': [{'a': 'abc', 'b': 12}, {'c': 'bcd'}]}
+    data = {'data_file': [{'a': 'abc', 'b': 12}, {'c': 'bcd'}]}
     pandas_data.from_data(data)
     pd.testing.assert_frame_equal(
-        pandas_data['obj_type'],
+        pandas_data['data_file'].contents,
         pd.DataFrame([{
             'a': 'abc', 'b': 12, 'c': None
         }, {
@@ -59,9 +59,9 @@ def test_pandas_dataset_list_of_objects_different_keys():
         }]),
         check_dtype=False,
     )
-    assert_pandas_frame_dtypes(pandas_data['obj_type'], ('string', 'Int64', 'string'))
+    assert_pandas_frame_dtypes(pandas_data['data_file'], ('string', 'Int64', 'string'))
     assert pandas_data.to_data() == {
-        'obj_type': [{
+        'data_file': [{
             'a': 'abc', 'b': 12, 'c': None
         }, {
             'a': None, 'b': None, 'c': 'bcd'
@@ -77,19 +77,19 @@ Pandas converts 'a' column into 'Int64' since all values can be cast into intege
 """)
 def test_pandas_dataset_list_of_objects_float_numbers():
     pandas_data = PandasDataset()
-    data = {'obj_type': [{'a': 12.0, 'b': 12.1}, {'a': 3.0}]}
+    data = {'data_file': [{'a': 12.0, 'b': 12.1}, {'a': 3.0}]}
     pandas_data.from_data(data)
     pd.testing.assert_frame_equal(
-        pandas_data['obj_type'],
+        pandas_data['data_file'].contents,
         pd.DataFrame([{
             'a': 12.0, 'b': 12.1
         }, {
             'a': 3.0, 'b': None
         }]),
     )
-    assert_pandas_frame_dtypes(pandas_data['obj_type'], ('Float64', 'Float64'))
+    assert_pandas_frame_dtypes(pandas_data['data_file'], ('Float64', 'Float64'))
     assert not DeepDiff(
-        pandas_data.to_data(), {'obj_type': [{
+        pandas_data.to_data(), {'data_file': [{
             'a': 12.0, 'b': 12.1
         }, {
             'a': 3.0, 'b': np.nan
@@ -100,7 +100,7 @@ def test_pandas_dataset_list_of_objects_float_numbers():
 def test_pandas_dataset_list_of_objects_float_numbers_and_missing_values():
     pandas_data = PandasDataset()
     data = {
-        'obj_type': [
+        'data_file': [
             {
                 'int': 12, 'float': 12.1, 'bool': True, 'str': 'abc'
             },
@@ -115,7 +115,7 @@ def test_pandas_dataset_list_of_objects_float_numbers_and_missing_values():
     pandas_data.from_data(data)
 
     pd.testing.assert_frame_equal(
-        pandas_data['obj_type'],
+        pandas_data['data_file'].contents,
         pd.DataFrame([{
             'int': 12, 'float': 12.1, 'bool': True, 'str': 'abc'
         }, {
@@ -126,10 +126,10 @@ def test_pandas_dataset_list_of_objects_float_numbers_and_missing_values():
         check_dtype=False,
     )
 
-    assert_pandas_frame_dtypes(pandas_data['obj_type'], ('Int64', 'Float64', 'boolean', 'string'))
+    assert_pandas_frame_dtypes(pandas_data['data_file'], ('Int64', 'Float64', 'boolean', 'string'))
 
     assert pandas_data.to_data() == {
-        'obj_type': [{
+        'data_file': [{
             'int': 12, 'float': 12.1, 'bool': True, 'str': 'abc'
         }, {
             'int': -3, 'float': None, 'bool': False, 'str': None
@@ -141,28 +141,28 @@ def test_pandas_dataset_list_of_objects_float_numbers_and_missing_values():
 
 def test_pandas_dataset_list_of_nested_objects():
     pandas_data = PandasDataset()
-    data = {'obj_type': [{'a': 'abc', 'b': {'c': [1, 3]}}]}
+    data = {'data_file': [{'a': 'abc', 'b': {'c': [1, 3]}}]}
     pandas_data.from_data(data)
     pd.testing.assert_frame_equal(
-        pandas_data['obj_type'],
+        pandas_data['data_file'].contents,
         pd.DataFrame([{
             'a': 'abc', 'b': {
                 'c': [1, 3]
             }
         }]),
         check_dtype=False)
-    assert_pandas_frame_dtypes(pandas_data['obj_type'], ('string', 'object'))
+    assert_pandas_frame_dtypes(pandas_data['data_file'], ('string', 'object'))
     assert pandas_data.to_data() == data
-    assert pandas_data['obj_type'].loc[0, 'b'] == {'c': [1, 3]}
+    assert pandas_data['data_file'].contents.loc[0, 'b'] == {'c': [1, 3]}
 
 
 @pytest.mark.skipif(os.getenv('OMNIPY_FORCE_SKIPPED_TEST') != '1', reason='To be implemented later')
 def test_pandas_dataset_missing_values():
     pandas_data = PandasDataset()
     pandas_data.from_data(
-        {'obj_type': [dict(a=1, b='a', c=1.0, d=True), dict(a=None, b=None, c=None, d=None)]})
+        {'data_file': [dict(a=1, b='a', c=1.0, d=True), dict(a=None, b=None, c=None, d=None)]})
     assert pandas_data.to_data() == {
-        'obj_type': [dict(a=1, b='a', c=1.0, d=True), dict(a=None, b='', c=nan, d=None)]
+        'data_file': [dict(a=1, b='a', c=1.0, d=True), dict(a=None, b='', c=nan, d=None)]
     }
 
 
@@ -170,34 +170,35 @@ def test_pandas_dataset_empty_list():
     pandas_data = PandasDataset()
     assert pandas_data.to_data() == {}
 
-    pandas_data.from_data({'obj_type': []})
-    assert isinstance(pandas_data['obj_type'], pd.DataFrame) and pandas_data['obj_type'].empty
-    assert pandas_data.to_data() == {'obj_type': []}
+    pandas_data.from_data({'data_file': []})
+    assert isinstance(pandas_data['data_file'].contents,
+                      pd.DataFrame) and pandas_data['data_file'].contents.empty
+    assert pandas_data.to_data() == {'data_file': []}
 
 
 def test_pandas_dataset_error_not_list():
     pandas_data = PandasDataset()
     with pytest.raises(ValueError):
-        pandas_data['obj_type'] = '1'
+        pandas_data['data_file'] = '1'
 
 
 def test_pandas_dataset_error_list_items_not_objects():
     pandas_data = PandasDataset()
     with pytest.raises(ValidationError):
-        pandas_data['obj_type'] = [123, 234]
+        pandas_data['data_file'] = [123, 234]
 
 
 def test_pandas_dataset_error_objects_keys_not_str():
     pandas_data = PandasDataset()
     with pytest.raises(ValidationError):
-        pandas_data['obj_type'] = [{123: 'abc', 'b': 12}]
+        pandas_data['data_file'] = [{123: 'abc', 'b': 12}]
 
 
 def test_pandas_dataset_error_empty_objects():
     # We might want to reevaluate how to handle empty objects later
     pandas_data = PandasDataset()
     with pytest.raises(ValidationError):
-        pandas_data['obj_type'] = [{'a': 'abc', 'b': 12}, {}]
+        pandas_data['data_file'] = [{'a': 'abc', 'b': 12}, {}]
 
 
 def test_pandas_model_input_output_data():

--- a/tests/modules/pandas/test_pandas.py
+++ b/tests/modules/pandas/test_pandas.py
@@ -43,7 +43,7 @@ def test_pandas_dataset_json_list_of_objects_same_keys():
         check_dtype=False,
     )
     assert_pandas_frame_dtypes(pandas_data['data_file'], ('string', 'Int64'))
-    assert pandas_data.to_json() == json_data
+    assert pandas_data.to_json(pretty=False) == json_data
 
 
 def test_pandas_dataset_list_of_objects_different_keys():

--- a/tests/modules/pandas/test_serialize_pandas.py
+++ b/tests/modules/pandas/test_serialize_pandas.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 from omnipy.modules.pandas.models import PandasDataset
 from omnipy.modules.pandas.serializers import PandasDatasetToTarFileSerializer
 
@@ -7,27 +9,27 @@ from .util import assert_pandas_dataset_equals
 
 def test_pandas_dataset_serializer_to_tar_file():
     pandas_data = PandasDataset()
-    pandas_data.from_data({'obj_type_1': [{'a': 'abc', 'b': 12}, {'a': 'bcd', 'b': 23}]})
-    pandas_data.from_data({'obj_type_2': [{'a': 'abc', 'b': 12}, {'c': 'bcd'}]})
+    pandas_data.from_data({'data_file_1': [{'a': 'abc', 'b': 12}, {'a': 'bcd', 'b': 23}]})
+    pandas_data.from_data({'data_file_2': [{'a': 'abc', 'b': 12}, {'c': 'bcd'}]})
     # fmt: off
-    obj_type_1_csv = """
-a,b
-abc,12
-bcd,23
-"""[1:]
+    data_file_1_csv = dedent("""\
+        a,b
+        abc,12
+        bcd,23
+        """)
 
-    obj_type_2_csv = """
-a,b,c
-abc,12,
-,,bcd
-"""[1:]
+    data_file_2_csv = dedent("""\
+        a,b,c
+        abc,12,
+        ,,bcd
+        """)
 
     serializer = PandasDatasetToTarFileSerializer()
     tarfile_bytes = serializer.serialize(pandas_data)
     decode_func = lambda x: x.decode('utf8')  # noqa
 
-    assert_tar_file_contents(tarfile_bytes, 'obj_type_1', 'csv', decode_func, obj_type_1_csv)
-    assert_tar_file_contents(tarfile_bytes, 'obj_type_2', 'csv', decode_func, obj_type_2_csv)
+    assert_tar_file_contents(tarfile_bytes, 'data_file_1', 'csv', decode_func, data_file_1_csv)
+    assert_tar_file_contents(tarfile_bytes, 'data_file_2', 'csv', decode_func, data_file_2_csv)
 
     deserialized_pandas_data = serializer.deserialize(tarfile_bytes)
 

--- a/tests/modules/pandas/util.py
+++ b/tests/modules/pandas/util.py
@@ -11,4 +11,5 @@ def assert_pandas_dataset_equals(pandas_dataset_1: PandasDataset,
                                  pandas_dataset_2: PandasDataset) -> None:
     assert pandas_dataset_1.keys() == pandas_dataset_2.keys()
     for key in pandas_dataset_1.keys():
-        pd.testing.assert_frame_equal(pandas_dataset_1[key], pandas_dataset_2[key])
+        pd.testing.assert_frame_equal(pandas_dataset_1[key].contents,
+                                      pandas_dataset_2[key].contents)


### PR DESCRIPTION
+ Initial hacky implementation of `Dataset.save()` and `load()`. Needs refactoring
+ Added `absorb()` and `absorb_and_replace()` methods.
+ Dataset `__getitem__` -> `Model` instead of data. Example:
    ```python
    dataset = Dataset[Model[int]](a=5)
    assert dataset['a'] == Model[int](5) != 5
    ```
+ Fixed `__name__`, `__qualname__`, `__module__` and `__repr__` for Dataset and Model
+ Bugfixes and code cleanup